### PR TITLE
Optimus: Change dependabot to run daily not weekly [Optimus-1710850045646] [Optimus-1710850186213]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
@@ -8,4 +9,5 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"
+


### PR DESCRIPTION
Trying to solve issue https://api.github.com/repos/AmigoAppAI/open-gpt/issues/7
‎
Update the Dependabot configuration file to trigger dependency updates daily instead of weekly.