### PR TITLE
Optimus: Change dependabot to run daily not weekly

### DIFF
--- a/optimus-bot.patch
+++ b/optimus-bot.patch
@@ -1,4 +1,5 @@
-
+UPDATE .github/dependabot.yml
+```
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
@@ -11,3 +12,4 @@ updates:
     schedule:
       interval: "daily"
 
+```


### PR DESCRIPTION
Working on [Optimus: Change dependabot to run daily not weekly](https://github.com/AmigoAppAI/open-gpt/issues/6)
‎
Change the Dependabot configuration to schedule dependency updates on a daily basis instead of weekly.