### PR TITLE
Optimus: Change dependabot to run daily not weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
@@ -8,4 +9,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
Working on [Optimus: Change dependabot to run daily not weekly](https://github.com/AmigoAppAI/open-gpt/pull/15)
‎
Updated the `.github/dependabot.yml` configuration to change Dependabot's schedule from weekly to daily.